### PR TITLE
Cross-compile Scala 2.10 and 2.11

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -23,8 +23,8 @@ object BuildSettings {
     organization  := "com.github.piotrga",
     version       := "2.0.0",
     description   := "Asynchronous Scala client for Amazon DynamoDB",
-    scalaVersion  := "2.10.1",
-    //crossScalaVersions := Seq("2.10.1", "2.11.4"),
+    scalaVersion  := "2.10.5",
+    crossScalaVersions := Seq("2.10.5", "2.11.7"),
     scalacOptions := Seq("-deprecation", "-feature", "-encoding", "utf8"),
     resolvers     ++= Dependencies.resolutionRepos
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,9 +23,9 @@ object Dependencies {
     // Java
     val awsSdk      = "1.7.5"
     // Scala
-    val akkaActor   = "2.2.3"
+    val akkaActor   = "2.3.12"
     // Test
-    val scalatest   = "1.9.1"
+    val scalatest   = "2.2.4"
     val log4j       = "1.2.17"
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.8

--- a/src/main/scala/com.github.piotrga/asyncdynamo/Dynamo.scala
+++ b/src/main/scala/com.github.piotrga/asyncdynamo/Dynamo.scala
@@ -29,7 +29,7 @@ import com.amazonaws.services.dynamodbv2.model._
 
 // Akka
 import akka.actor._
-import akka.routing.SmallestMailboxRouter
+import akka.routing.SmallestMailboxPool
 import com.typesafe.config.ConfigFactory
 import akka.actor.Status.Failure
 
@@ -96,7 +96,7 @@ object Dynamo {
 
     system.actorOf(Props(new Actor {
       val router = context.actorOf(Props(dynamo)
-        .withRouter(SmallestMailboxRouter(connectionCount))
+        .withRouter(SmallestMailboxPool(connectionCount))
         .withDispatcher("dynamo-connection-dispatcher"), "DynamoConnection")
 
       def receive = {

--- a/src/test/scala/com.github.piotrga.asyncdynamo/AdminOperationsTest.scala
+++ b/src/test/scala/com.github.piotrga.asyncdynamo/AdminOperationsTest.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeoutException
 
 // ScalaTest
 import org.scalatest.FreeSpec
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 
 // This project
 import blocking._

--- a/src/test/scala/com.github.piotrga.asyncdynamo/DynamoObjectTest.scala
+++ b/src/test/scala/com.github.piotrga.asyncdynamo/DynamoObjectTest.scala
@@ -20,7 +20,7 @@ import concurrent.duration._
 import language.postfixOps
 
 // ScalaTest
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 import org.scalatest.FreeSpec
 
 // This project

--- a/src/test/scala/com.github.piotrga.asyncdynamo/DynamoReaderMonadTest.scala
+++ b/src/test/scala/com.github.piotrga.asyncdynamo/DynamoReaderMonadTest.scala
@@ -19,7 +19,7 @@ package com.github.piotrga.asyncdynamo
 import java.util.UUID
 
 // ScalaTest
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 import org.scalatest.FreeSpec
 
 // This project

--- a/src/test/scala/com.github.piotrga.asyncdynamo/OperationsTest.scala
+++ b/src/test/scala/com.github.piotrga.asyncdynamo/OperationsTest.scala
@@ -28,7 +28,7 @@ import language.postfixOps
 import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException, ComparisonOperator, ScalarAttributeType}
 
 // ScalaTest
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 import org.scalatest.FreeSpec
 
 // Akka

--- a/src/test/scala/com.github.piotrga.asyncdynamo/functional/IterateeTest.scala
+++ b/src/test/scala/com.github.piotrga.asyncdynamo/functional/IterateeTest.scala
@@ -21,7 +21,7 @@ import language.postfixOps
 
 // ScalaTest
 import org.scalatest.FreeSpec
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 
 // This project
 import Iteratee._


### PR DESCRIPTION
Cross-Compile to 2.11 and 2.10. Also, upgrade dependencies so that 2.11 works, and bump SBT version to latest.
- Update ScalaTest dependency, and fix deprecated class usage.
- Update Akka dependency, and fix deprecated class usage.

The automated tests work for me, connecting to my own AWS account. I spent a bit of time making them work with DynamoDB Local, but I think it would make sense to put that in a separate issue/PR... along with making the Travis build use the local version.

This should help solve issue #31 
